### PR TITLE
Update day.ts

### DIFF
--- a/src/shared/period/day.ts
+++ b/src/shared/period/day.ts
@@ -48,7 +48,7 @@ export class Day {
   }
 
   static fromString(str: string){
-    return new Day(moment(str));
+    return new Day(moment(str, 'YYYY-MM-DD'));
   }
 
   static fromJsDate(date: Date){


### PR DESCRIPTION
Fixes day-of-week displaying one day behind in UTC-4/UTC-5 timezones.

moment(str) parses YYYY-MM-DD as UTC midnight, causing the day to 
appear as the previous local day. Fixes #8, #13