### PR TITLE
Fix dark and light mode theme colors

### DIFF
--- a/src/app/ui/DailyRoutineView.tsx
+++ b/src/app/ui/DailyRoutineView.tsx
@@ -29,7 +29,7 @@ const tabCss = css({
 
 export const DailyRoutineView = () => {
   const { tab, route } = useTabRoute();
-  const { view, leafBgColor } = useLeaf();
+  const { view } = useLeaf();
 
   useEffect(() => {
     view.contentEl.classList.add("no-padding");
@@ -72,7 +72,7 @@ export const DailyRoutineView = () => {
         onChange={onTabChange}
         css={{
           zIndex: 1000,
-          backgroundColor: leafBgColor,
+          backgroundColor: "var(--background-primary)",
           position: "fixed",
           minHeight: 0,
           width: "100%",
@@ -107,7 +107,7 @@ export const DailyRoutineView = () => {
         position: "fixed",
         width: "100%",
         height: tabsBottomGap,
-        backgroundColor: leafBgColor,
+        backgroundColor: "var(--background-primary)",
         bottom: 0,
         zIndex: 1000,
       }} />

--- a/src/features/performance/PerformanceCircle.tsx
+++ b/src/features/performance/PerformanceCircle.tsx
@@ -22,6 +22,7 @@ const accomplishmentCircleColor = "hsl(var(--color-accent-hsl))";
 interface PercentageCircleProps {
   performance: NotePerformance;
   text: string;
+  textColor?: string;
   transition?: boolean;
   width?: string;
   className?: string;
@@ -31,6 +32,7 @@ export const PerformanceCircle = React.memo(({
   width,
   className,
   text,
+  textColor = "var(--text-normal)",
   transition=true
 }: PercentageCircleProps) => {
   const accomplishment = cleanPercentage(performance.accomplishment);
@@ -48,6 +50,7 @@ export const PerformanceCircle = React.memo(({
         textAnchor="middle"
         fontSize="45"
         dominantBaseline="central"
+        fill={textColor}
       >
         {text}
       </text>

--- a/src/features/routine/ui/active-criteria-month.tsx
+++ b/src/features/routine/ui/active-criteria-month.tsx
@@ -16,7 +16,7 @@ const calendarCss = css({
   ".react-calendar": {
     width: "100%",
     maxWidth: "100%",
-    background: "white",
+    background: "var(--background-primary)",
     lineHeight: "1.125em",
   },
 
@@ -119,7 +119,7 @@ const CalendarTile = ({ date, active }: CalendarTileProps) => {
       })
     } else {
       return css({
-        color: "black"
+        color: "var(--text-normal)"
       });
     }
   }, [active]);

--- a/src/features/task-el/ui/BaseTaskFeature.tsx
+++ b/src/features/task-el/ui/BaseTaskFeature.tsx
@@ -146,6 +146,7 @@ export const BaseTaskFeature = React.memo(<T extends Task>({
           ".MuiTouchRipple-child": {
             backgroundColor: "var(--color-accent-1) !important",
           },
+          color: "var(--text-normal)",
           width: "100%",
         }}
       >

--- a/src/features/task-el/ui/BaseTaskGroupFeature.tsx
+++ b/src/features/task-el/ui/BaseTaskGroupFeature.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { NoteEntity, noteRepository, RoutineNote, TaskEntity, TaskGroup, TaskGroupEntity } from '@entities/note';
-import { Accordion, AccordionDetails, AccordionSummary, accordionSummaryClasses } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
 import { Icon } from '@shared/components/Icon';
 import { Touchable } from '@shared/components/Touchable';
 import { dr } from '@shared/utils/daily-routine-bem';
@@ -38,7 +38,6 @@ export const BaseTaskGroupFeature = React.memo(({
 }: Props) => {
   const groupRef = useRef<HTMLDivElement>(null);
   const [groupMode, setGroupMode] = useState<GroupMode>("idle");
-  const bgColor = useLeaf(s=>s.leafBgColor);
   const { note, setNote } = useRoutineNote();
 
 
@@ -140,7 +139,7 @@ export const BaseTaskGroupFeature = React.memo(({
         expanded={open}
         onChange={() => changeOpen(!open)}
         css={{
-          backgroundColor: bgColor,
+          backgroundColor: "var(--background-primary)",
           "&::before": {
             display: "none",
           }
@@ -182,10 +181,15 @@ export const BaseTaskGroupFeature = React.memo(({
                 flexDirection: "row-reverse",
                 gap: "0.5em",
                 fontWeight: "500",
-
-                // 열림상태
-                [`& .${accordionSummaryClasses.expandIconWrapper}.${accordionSummaryClasses.expanded}`]: {
-                  transform: 'rotate(90deg)',
+                color: "var(--text-normal)",
+                "& .MuiAccordionSummary-content": {
+                  color: "var(--text-normal)",
+                },
+                "& .MuiAccordionSummary-expandIconWrapper": {
+                  color: "var(--icon-color)",
+                },
+                "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
+                  transform: "rotate(90deg)",
                 },
               }}
             >

--- a/src/features/task-el/ui/CancelLineName.tsx
+++ b/src/features/task-el/ui/CancelLineName.tsx
@@ -8,6 +8,7 @@ const bem = dr("task-name");
 const baseStyle = css({
   position: "relative",
   cursor: "pointer",
+  color: "var(--text-normal)",
   transition: "color 0.5s ease",
   "&:after": {
     content: "''",
@@ -17,16 +18,15 @@ const baseStyle = css({
     width: 0,
     transform: "translateY(-50%)",
     height: "1.5px", // check 취소선 두께
-    background: "var(--color-base-60)", // check 취소선 색
+    background: "var(--text-muted)",
   }
 })
 
 const cancelTextStyle = css({
-  color: "var(--color-base-35)", // check된 상태에서 글자색
+  color: "var(--text-muted)",
 })
 
 const cancelLineStyle = css({
-  color: "var(--color-base-40)",
   "&:after": {
     width: "100%",
     transition: "all 0.5s ease",
@@ -44,7 +44,7 @@ export const CancelLineName = ({
   return (
     <span 
       className={bem("name")}
-      css={[baseStyle, cancel && cancelTextStyle && cancelLineStyle]}
+      css={[baseStyle, cancel && cancelTextStyle, cancel && cancelLineStyle]}
     >
       {name}
     </span>

--- a/src/features/task-el/ui/OptionIcon.tsx
+++ b/src/features/task-el/ui/OptionIcon.tsx
@@ -16,7 +16,7 @@ export const OptionIcon = ({
       onMenuShow={onOptionMenu}
       icon="ellipsis"
       css={{
-        color: 'var(--color-base-40)',
+        color: "var(--icon-color)",
         width: "3em",
       }}
     />

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -20,7 +20,7 @@ export const Button = (props: ButtonProps) => {
     switch(props.variant){
       // PRIMARY
       case "primary": return css({
-        color: "black"
+        color: "var(--text-normal)"
       });
       // DESTRUCTIVE
       case "destructive": return css({

--- a/src/widgets/weeks/DayNodeComponent.tsx
+++ b/src/widgets/weeks/DayNodeComponent.tsx
@@ -15,11 +15,11 @@ interface DayNodeProps {
   onClick: (day: Day, event?: React.MouseEvent) => void;
 }
 export const DayNodeComponent = React.memo(({ dayNode: { day, performance: _performance }, onClick }: DayNodeProps) => {
-  const { leafBgColor } = useLeaf();
   // const isToday = useMemo(() => day.isSameDay(Day.now()), [day]);
 
   const activeNode = useWeeksActiveDay();
   const isActiveDay = useMemo(() => day.isSameDay(activeNode.day), [activeNode.day, day]);
+  const isFutureDay = useMemo(() => day.isAfter(Day.today()), [day]);
   const [performance, setPerformance] = useState(_performance);
 
   /**
@@ -43,10 +43,10 @@ export const DayNodeComponent = React.memo(({ dayNode: { day, performance: _perf
       right: "0",
       bottom: "0",
       borderRadius: "7px",
-      backgroundColor: leafBgColor,
+      backgroundColor: "var(--background-primary)",
       opacity: "0.7",
     })
-  }, [day, leafBgColor]);
+  }, [day]);
 
   const activeStyle = useMemo(() => {
     if(!isActiveDay) return { self: {}, after: {} };
@@ -55,6 +55,10 @@ export const DayNodeComponent = React.memo(({ dayNode: { day, performance: _perf
       after: { boxShadow: "inset 0 0 2px 0.5px rgba(0, 0, 0, 0.5)" },
     }
   }, [isActiveDay]);
+
+  const textColor = useMemo(() => {
+    return isFutureDay ? "var(--text-muted)" : "var(--text-normal)";
+  }, [isFutureDay]);
 
   const bem = dr("weeks");
   return (
@@ -80,6 +84,9 @@ export const DayNodeComponent = React.memo(({ dayNode: { day, performance: _perf
         textAlign: "center",
         fontSize: "0.8em",
         height: "1em",
+        color: textColor,
+        position: "relative",
+        zIndex: 1,
       }}
     >
       {day.format("M/D").toUpperCase()}
@@ -88,9 +95,11 @@ export const DayNodeComponent = React.memo(({ dayNode: { day, performance: _perf
       css={{
         position: "relative",
         bottom: "0px",
+        zIndex: 1,
       }}
       width="100%"
       performance={performance}
+      textColor={textColor}
       text={day.format("ddd").toUpperCase()} 
     />
   </div>

--- a/src/widgets/weeks/WeeksWidget.tsx
+++ b/src/widgets/weeks/WeeksWidget.tsx
@@ -23,8 +23,6 @@ export const WeeksWidget = ({ className }: WeeksProps) => {
   const activeWeek = useMemo(() => Week.of(activeDay), [activeDay]);
   const currentNotePerformance = useMemo(() => NoteEntity.getPerformance(note), [note]);
   const [ weeks, setWeeks ] = useState<WeekNode[]>([]);
-  const { leafBgColor } = useLeaf();
-
   /**
    * weeks 최초 초기화
    */
@@ -76,7 +74,7 @@ export const WeeksWidget = ({ className }: WeeksProps) => {
             justifyContent: "center",
             alignItems: "stretch",
             flexWrap: "nowrap",
-            backgroundColor: leafBgColor,
+            backgroundColor: "var(--background-primary)",
           }}>
             {week.days.map((dayNode, idx) => (
               <DayNodeComponent


### PR DESCRIPTION
## Summary
 replace hardcoded black and white colors with Obsidian theme variables fix task, group, week navigation, and month calendar text colors for dark/light mode- replace stale leaf background usage in key surfaces with background-primary
## Testing
 npm run build
## Notes
focuses on theme color issues only- Loading state issue is not included in this PR